### PR TITLE
Exit when fails to connect to the master gateway

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,4 @@
-FROM golang:1.18-alpine as builder
-
-
+FROM golang:1.19-alpine as builder
 
 ENV GO111MODULE=
 
@@ -21,6 +19,8 @@ USER ks
 WORKDIR /home/ks/
 
 COPY --from=builder /work/build/gateway /usr/bin/gateway
+
+ARG image_version
 ENV RELEASE=$image_version
 
 ENTRYPOINT ["gateway"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubescape/gateway
 
-go 1.18
+go 1.19
 
 require (
 	github.com/armosec/cluster-notifier-api-go v0.0.3

--- a/pkg/notificationhandle.go
+++ b/pkg/notificationhandle.go
@@ -63,7 +63,7 @@ func (nh *Gateway) WebsocketNotificationHandler(w http.ResponseWriter, r *http.R
 		logger.L().Error("Method not allowed")
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
-		
+
 	}
 
 	conn, notificationAtt, err := nh.AcceptWebsocketConnection(w, r)
@@ -124,9 +124,7 @@ func (nh *Gateway) connectToMaster(notificationAtt map[string]string, retry int)
 	// connect to master
 	conn, _, err := nh.wa.DefaultDialer(parentURL.String())
 	if err != nil {
-		nh.outgoingConnectionsMutex.Unlock()
-		logger.L().Error("in connectToMaster", helpers.Error(err))
-		return
+		logger.L().Fatal("failed to connect to master", helpers.String("url", parentURL.String()), helpers.Error(err))
 	}
 	connObj, _ := nh.outgoingConnections.Append(att, conn)
 	nh.outgoingConnectionsMutex.Unlock()
@@ -163,7 +161,7 @@ func (nh *Gateway) connectToMaster(notificationAtt map[string]string, retry int)
 
 		nh.CleanupOutgoingConnection(att)
 		if nh.outgoingConnections.Len() == 0 && nh.incomingConnections.Len() > 0 {
-			panic(fmt.Sprintf("failed to connect to parent: '%s'", strutils.ObjectToString(att)))
+			logger.L().Fatal(fmt.Sprintf("failed to connect to parent: '%s'", strutils.ObjectToString(att)))
 		}
 	}
 }
@@ -378,5 +376,5 @@ func setupParentInfo(config *armometadata.ClusterConfig) {
 	if parent := os.Getenv(ParentGatewayHostEnvironmentVariable); parent != "" {
 		config.RootGatewayURL = parent
 	}
-	
+
 }


### PR DESCRIPTION
1. Update to go version `1.19`
2. Exit when fails to connect to the master gateway