### PR TITLE
use go 1.21 in Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.20-bullseye as builder
+FROM --platform=$BUILDPLATFORM golang:1.21-bullseye as builder
 
 ENV GO111MODULE=on CGO_ENABLED=0
 WORKDIR /work


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Updated the Go version in the Dockerfile to use version 1.21, ensuring compatibility with the latest Go features and improvements.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update Go version to 1.21 in Dockerfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build/Dockerfile
<li>Updated the base image from <code>golang:1.20-bullseye</code> to <br><code>golang:1.21-bullseye</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/gateway/pull/32/files#diff-5aecd73bbcb9b7410938673269f0d4e676dd18509277b0ff2f2787c9d3e22604">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

